### PR TITLE
OCaml 5 compatibility: remove the use of naked pointers

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -1,7 +1,4 @@
-(executables
-  (names
-    tutorial
-    rosenbrock
-  )
+(tests
+  (names tutorial rosenbrock)
   (libraries nlopt)
 )

--- a/src/nlopt_wrapper.c
+++ b/src/nlopt_wrapper.c
@@ -262,6 +262,7 @@ value ml_nlopt_optimize(value ml_opt, value ml_x)
 
     for(int i=0; i < len; i++)
 	Store_double_field(ml_xopt, i, x[i]);    
+    free(x);
     
     ml_rv = caml_alloc(3, 0);
     

--- a/src/nlopt_wrapper.c
+++ b/src/nlopt_wrapper.c
@@ -86,7 +86,7 @@ static const nlopt_result map_results[] = {
     NLOPT_MAXTIME_REACHED
 };
 
-int map_nlopt_result(nlopt_result result)
+static int map_nlopt_result(nlopt_result result)
 {
     int i;
 
@@ -98,7 +98,7 @@ int map_nlopt_result(nlopt_result result)
 }
 
 
-void ml_nlopt_finalize(value ml_opt)
+static void ml_nlopt_finalize(value ml_opt)
 {
     nlopt_opt opt = (nlopt_opt) Field(ml_opt, 1);
     value *cb = (value *) Field(ml_opt, 2);


### PR DESCRIPTION
I had an application that was crashing on OCaml 5 with heap corruption, and valgrind was showing a lot of errors too (mostly about reading values 8 bytes before allocation, which is an indication that a 'malloc'-ed value is used as an OCaml value).

This PR removes the use of naked pointers (which can be detected on OCaml 4.14.1 with the nnpchecker flag, and is the default since OCaml 5.0).

It also fixes some unsafe mixing of OCaml and C values that were unsafe even before OCaml 4.14: using 'Store_field' on custom blocks.

Now using 'nlopt' no longer results in SIGSEGV on OCaml 5, and both valgrind and the naked pointer checker are happy under 4.14.